### PR TITLE
Make sqlite query more robust

### DIFF
--- a/sciunit2/records.py
+++ b/sciunit2/records.py
@@ -131,16 +131,8 @@ class ExecutionManager(object):
         k, v = self.__pending   # eid, Metadata
         v.size = size
         # self.__f[k] = str(v)
-
-        script = """
-            insert into revs (data)
-            values (
-                '""" + str(v) + """'
-
-                );
-                """
-
-        self.__c.executescript(script)
+        script = "insert into revs (data) values (?)"
+        self.__c.execute(script, [v])
         self.__f.commit()
 
         return self.__to_rev(k), v
@@ -165,9 +157,9 @@ class ExecutionManager(object):
         #     return self.__f.db.get(i)
         # except KeyError:
         #     raise CommandError('execution %r not found' % self.__to_rev(i))
-        script = "select * from revs where id = " + str(i)
+        script = "select * from revs where id = ?"
 
-        row = self.__c.execute(script).fetchone()
+        row = self.__c.execute(script, [i]).fetchone()
 
         if row != None:
             return row[1]
@@ -188,9 +180,9 @@ class ExecutionManager(object):
         #     del self.__f[self.__to_id(rev)]
         # except KeyError:
         #     pass
-        script = "delete from revs where id = " + str(self.__to_id(rev))
+        script = "delete from revs where id = ?"
         # delete record
-        self.__c.execute(script)
+        self.__c.execute(script, [self.__to_id(rev)])
         self.__f.commit()
 
     def delete_id(self, id):


### PR DESCRIPTION
Sciunit will fail when an argument contains an apostrophe.

For example:

```
$ sciunit exec sh -c "echo 'hello'"
Traceback (most recent call last):
  File "/nix/store/k708yhw0wpw713hzqxbgz77nciwjl4hr-python3.10-sciunit2-0.4.post82.dev130189670/bin/.sciunit-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/k3dvzagbrfnddyzdjswxic4qh9byks00-python3-3.10.13-env/lib/python3.10/site-packages/sciunit2/cli.py", line 64, in main
    _main(sys.argv[1:])
  File "/nix/store/k3dvzagbrfnddyzdjswxic4qh9byks00-python3-3.10.13-env/lib/python3.10/site-packages/sciunit2/cli.py", line 101, in _main
    r = cmd.run(args[1:])
  File "/nix/store/k3dvzagbrfnddyzdjswxic4qh9byks00-python3-3.10.13-env/lib/python3.10/site-packages/sciunit2/command/exec_/__init__.py", line 36, in run
    return self.do_commit('cde-package', rev, emgr, repo)
  File "/nix/store/k3dvzagbrfnddyzdjswxic4qh9byks00-python3-3.10.13-env/lib/python3.10/site-packages/sciunit2/command/mixin.py", line 20, in do_commit
    return (repo.location,) + emgr.commit(sz)
  File "/nix/store/k3dvzagbrfnddyzdjswxic4qh9byks00-python3-3.10.13-env/lib/python3.10/site-packages/sciunit2/records.py", line 150, in commit
    raise exc
  File "/nix/store/k3dvzagbrfnddyzdjswxic4qh9byks00-python3-3.10.13-env/lib/python3.10/site-packages/sciunit2/records.py", line 144, in commit
    self.__c.executescript(script)
sqlite3.OperationalError: near "hello": syntax error
```

The query that sciunit generates looks like this;
```
            insert into revs (data)
            values (
                '{"cmd":["sh","-c","echo 'hello'"],"started":"2024-02-08T21:00:16.671802Z","size":229683200}'
            );
```
Since the third line is delimited by apostrophes, and third argument, `echo 'hello'`, contains an apostrophe, it breaks the query.

Instead of this Python sqlite supports using `?` as a [place-holder](https://docs.python.org/3/library/sqlite3.html#how-to-use-placeholders-to-bind-values-in-sql-queries) for that argument. If we use placeholder, then the statement will be parsed correctly, even if the value of the placeholder has an apostrophe or any other special character.