### PR TITLE
fix: pipes -> shlex module in util.py,workspace.py

### DIFF
--- a/sciunit2/util.py
+++ b/sciunit2/util.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 import os
-import pipes
+import shlex
 import tempfile
 import itertools
 import errno
@@ -10,11 +10,11 @@ from glob import glob
 
 
 def quoted_format(fmt, *args):
-    return fmt.format(*map(pipes.quote, args))
+    return fmt.format(*map(shlex.quote, args))
 
 
 def quoted(args):
-    return ' '.join(map(pipes.quote, args))
+    return ' '.join(map(shlex.quote, args))
 
 
 # expands 'ptrn' into a list of filenames in the style of unix glob(3),

--- a/sciunit2/workspace.py
+++ b/sciunit2/workspace.py
@@ -12,7 +12,7 @@ import sciunit2.wget
 import os
 import shutil
 import re
-import pipes
+import shlex
 import errno
 from urllib.parse import urlparse
 import urllib.request
@@ -90,14 +90,14 @@ def _create(name, by, overwrite=False):
         ret = by(_dir)
     if not ret:
         raise CommandError('directory %s already exists' %
-                           pipes.quote(location_for(name)))
+                           shlex.quote(location_for(name)))
 
 
 # checks if the given folder exists
 def _delete(name, by):
     if not by(location_for(name)):
         raise CommandError('directory %s does not exists for delete operation' %
-                           pipes.quote(location_for(name)))
+                           shlex.quote(location_for(name)))
 
 
 # opens a sciunit container already created


### PR DESCRIPTION
`pipes` module has been removed from python 3.13. The `quote` function recommended replacement is in the `shlex` module.